### PR TITLE
Display debug statements using println

### DIFF
--- a/ethcore/wasm/src/runtime.rs
+++ b/ethcore/wasm/src/runtime.rs
@@ -629,7 +629,7 @@ impl<'a> Runtime<'a> {
 
 	fn debug(&mut self, args: RuntimeArgs) -> Result<()>
 	{
-		println!(target: "wasm", "Contract debug message: {}", {
+		println!("Contract debug message: {}", {
 			let msg_ptr: u32 = args.nth_checked(0)?;
 			let msg_len: u32 = args.nth_checked(1)?;
 

--- a/ethcore/wasm/src/runtime.rs
+++ b/ethcore/wasm/src/runtime.rs
@@ -629,7 +629,7 @@ impl<'a> Runtime<'a> {
 
 	fn debug(&mut self, args: RuntimeArgs) -> Result<()>
 	{
-		trace!(target: "wasm", "Contract debug message: {}", {
+		println!(target: "wasm", "Contract debug message: {}", {
 			let msg_ptr: u32 = args.nth_checked(0)?;
 			let msg_len: u32 = args.nth_checked(1)?;
 


### PR DESCRIPTION
Makes seeing debug logs in run-contract a lot easier. 