### PR TITLE
Fix build: always include logging shim crate

### DIFF
--- a/ethcore/evm/src/lib.rs
+++ b/ethcore/evm/src/lib.rs
@@ -28,7 +28,7 @@ extern crate parity_bytes as bytes;
 #[macro_use]
 extern crate lazy_static;
 
-#[cfg_attr(feature = "evm-debug", macro_use)]
+#[macro_use]
 extern crate log;
 
 #[cfg(test)]


### PR DESCRIPTION
The `info!`s added to `ethcore/evm/interpreter/mod.rs` were undefined.