### PR TITLE
Adding buildkite pipeline to build the parity-ethereum docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,26 @@
+##################################
+# Docker image deployment pipeline
+##################################
+steps:
+  - label: Get docker tag and save it as metadata for use later
+    command: .buildkite/scripts/set_docker_tag_meta_data.sh
+
+  - wait
+
+  - label: Build docker image (all branch commits)
+    branches: "*"
+    command:
+      - .buildkite/scripts/build_tag_push_deployment_image.sh
+
+  - block: Human approval required to deploy docker image (master only)
+    branches: master
+    prompt: |
+      Clicking "OK" below will unblock this step and
+      permit the docker image to be tagged as latest
+      which means that the image will be used as a
+      base image for all runtime builds.
+
+  - label: Deploy docker image (master only)
+    branches: master
+    command:
+      - .buildkite/scripts/promote_deployment_image_to.sh latest

--- a/.buildkite/scripts/build_tag_push_deployment_image.sh
+++ b/.buildkite/scripts/build_tag_push_deployment_image.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+############################################################
+# Simple wrapper script to call
+# docker/docker_build_and_push.sh
+# with the correct arguments.
+#
+# This script is intended to have buildkite
+# specific things, like env vars and calling
+# the buildkite-agent binary. Keeping this
+# separate from the generic script that gets
+# called allows us to use and test the generic
+# scripts easily on a local dev box.
+############################################################
+
+# Helpful tips on writing build scripts:
+# https://buildkite.com/docs/pipelines/writing-build-scripts
+set -euxo pipefail
+
+deployment_image_tag=$(buildkite-agent meta-data \
+                       get \
+                       "deployment_image_tag"
+                     )
+
+docker/docker_build_and_push.sh \
+  ${BUILDKITE_COMMIT} \
+  ${deployment_image_tag}
+

--- a/.buildkite/scripts/get_docker_tag.bats
+++ b/.buildkite/scripts/get_docker_tag.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+##
+# Test file for get-docker-tags.sh
+#
+# If you are not familiar, check out
+# Bash Automated Testing System (BATS):
+# https://github.com/bats-core/bats-core
+##
+
+@test "Provide zero arguments should error" {
+  run ./get-docker-tag.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "\$1: unbound variable" ]]
+}
+
+@test "Provide only git_branch should error" {
+  run ./get-docker-tag.sh 'some_git_branch_name'
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "\$2: unbound variable" ]]
+}
+
+@test "Provide git_branch, git_commit_sha, and git_tag_name should succeed" {
+  run ./get-docker-tag.sh 'some_git_branch_name' 'some_git_commit_sha' 'some_git_tag_name'
+  [ "$status" -eq 0 ]
+}
+
+@test "Provide branch(master) and tag: should use tag as prefix" {
+  run ./get-docker-tag.sh 'master' 'some_sha' 'some_tag_name'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "some_tag_name-" ]]
+}
+
+@test "Provide branch(master) and no tag: should use master as prefix" {
+  run ./get-docker-tag.sh 'master' 'some_sha'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "master-" ]]
+}
+
+@test "Provide branch(non-master) and no tag: should use commit_sha" {
+  run ./get-docker-tag.sh 'non_master_branch' 'some_sha'
+  [ "$status" -eq 0 ]
+  [ "$output" = "some_sha" ]
+}

--- a/.buildkite/scripts/get_docker_tag.sh
+++ b/.buildkite/scripts/get_docker_tag.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+##
+# This is a build script to determine the value of the tag
+# to use when versioning the docker image.
+#
+# The value of the tag will be echo'd to stdout
+# so that the calling script can do something useful
+# with it. For example, make it available elsewhere
+# in the pipeline by saving it as an artifact/meta-data/etc.
+#
+# Usage:
+# get_docker_tag.sh [git_branch] [git_commit_sha] [git_tag]
+##
+
+# get_docker_tag $BUILDKITE_BRANCH $BUILDKITE_COMMIT $BUILDKITE_TAG
+
+set -euo pipefail
+
+git_branch_name=$1
+git_commit_sha=$2
+git_tag_name=${3:-NO_TAG_PROVIDED}
+
+# TODO possibly change to more human readable format:
+#      YYYY-mm-dd-HH-MM-SS
+timestamp=`date +%Y%m%d%H%M%S` # YYYYmmddHHMMSS
+
+if [ ${git_branch_name} = "master" ]; then
+    # If the current branch IS master, then we
+    # use a special value as the tag for the docker image.
+
+    # Use the current git tag as a prefix if it is
+    # defined. If not, use "master" as a default.
+    if [ ${git_tag_name} = "NO_TAG_PROVIDED" ]; then
+      prefix="master"
+    else
+      prefix=${git_tag_name}
+    fi
+
+    # Concat prefix and timestamp.
+    docker_image_tag=${prefix}-${timestamp}
+else
+    # If the current branch IS NOT master, then
+    # it is a pull request or feature branch.
+    # Use the git commit SHA1 as the tag for the docker image.
+    docker_image_tag=${git_commit_sha}
+fi
+
+# Echo the final tag value to stdout
+# so that the calling script can do
+# something useful with it.
+echo "${docker_image_tag}"

--- a/.buildkite/scripts/promote_deployment_image_to.sh
+++ b/.buildkite/scripts/promote_deployment_image_to.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+#############################################
+# Gets the deployment image tag from buildkite
+# metadata and promotes the deployment image
+# by retagging it with the provided tag.
+#
+# This script is intended to have buildkite
+# specific things, like env vars and calling
+# the buildkite-agent binary. Keeping this
+# separate from the generic script that gets
+# called allows us to use and test the generic
+# scripts easily on a local dev box.
+##############################################
+
+# Helpful tips on writing build scripts:
+# https://buildkite.com/docs/pipelines/writing-build-scripts
+set -euxo pipefail
+
+####################
+# Required arguments
+####################
+new_image_tag=$1
+
+#################
+# Local variables
+#################
+docker_image_name=oasislabs/testnet
+deployment_image_tag=$(buildkite-agent meta-data \
+                       get \
+                       "deployment_image_tag"
+                     )
+
+##############################################
+# Add the provided tag to the deployment image
+##############################################
+
+docker pull "${docker_image_name}:${deployment_image_tag}"
+
+docker tag \
+  "${docker_image_name}:${deployment_image_tag}" \
+  "${docker_image_name}:${new_image_tag}"
+
+docker push "${docker_image_name}:${new_image_tag}"

--- a/.buildkite/scripts/set_docker_tag_meta_data.sh
+++ b/.buildkite/scripts/set_docker_tag_meta_data.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+####################################################
+# Determines the correct docker tag to use
+# based on the current git branch/tag.
+# This tag is saved as metadata in the buildkite
+# pipeline so that it can be retrieved in steps
+# that want to pull the same exact image from
+# Docker Hub.
+#
+# This tag value must be calculated once and saved
+# as metadata in buildkite because it is possible
+# that the tag name includes a timestamp, which could
+# obviously change if the tag were recalculated.
+#
+# This script is intended to have buildkite
+# specific things, like env vars and calling
+# the buildkite-agent binary. Keeping this
+# separate from the generic script that gets
+# called allows us to use and test the generic
+# scripts easily on a local dev box.
+####################################################
+
+# Helpful tips on writing build scripts:
+# https://buildkite.com/docs/pipelines/writing-build-scripts
+set -euxo pipefail
+
+docker_tag=$(.buildkite/scripts/get_docker_tag.sh\
+              ${BUILDKITE_BRANCH:-unknown_git_branch} \
+              ${BUILDKITE_COMMIT:-unknown_git_commit} \
+              ${BUILDKITE_TAG}
+            )
+
+buildkite-agent \
+  meta-data set \
+  "deployment_image_tag" \
+  ${docker_tag}

--- a/.buildkite/scripts/setup_gitconfig.sh
+++ b/.buildkite/scripts/setup_gitconfig.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+################################################################
+# This script sets up gitconfig for Buildkite
+#
+# Usage:
+# setup_gitconfig.sh
+################################################################
+
+# Helpful tips on writing build scripts:
+# https://buildkite.com/docs/pipelines/writing-build-scripts
+set -euxo pipefail
+
+# Setup the Git configuration
+cat >/root/.gitconfig <<EOF
+# This is required for the CI/CD build agents
+# to run cargo build because the Cargo.toml
+# files declare dependencies to private git
+# repos using https:// and the build agents
+# use SSH keys to access those repos on GitHub.
+[url "ssh://git@github.com"]
+  insteadOf = https://github.com
+EOF

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:18.04 as intermediate
+
+# Add metadata identifying this image as an
+# intermediate build image so that we can
+# clean it up from our host after a successful
+# build
+LABEL stage=intermediate
+
+RUN apt-get update -qq && apt-get upgrade -qq && apt-get install -qq \
+  build-essential git gdb cmake libudev-dev \
+  curl wget unzip \
+  pkg-config software-properties-common \
+  python python-pyelftools \
+  # for rust openssl
+  libssl-dev libcurl4-openssl-dev \
+  # for rocksdb
+  libsnappy-dev librocksdb-dev \
+  # for benchmarks
+  python3-prometheus-client \
+  # convenience
+  golang
+
+ENV HOME="/root"
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
+
+# install rust version that we have validated against our tools
+RUN curl "https://sh.rustup.rs" -sfo rustup.sh && \
+  sh rustup.sh -y --default-toolchain nightly-2018-10-01
+
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
+
+ARG PARITY_ETHEREUM_COMMIT_SHA
+ARG PARITY_ETHEREUM_BUILD_IMAGE_TAG
+
+LABEL com.oasislabs.parity-ethereum-commit-sha="${PARITY_ETHEREUM_COMMIT_SHA}"
+LABEL com.oasislabs.parity-ethereum-build-image-tag="${PARITY_ETHEREUM_BUILD_IMAGE_TAG}"
+
+WORKDIR /code
+
+RUN git config --global credential.helper store && \
+  git config --global credential.https://github.com.username ${GITHUB_USER} && \
+  echo "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com" > ~/.git-credentials
+
+RUN rustup target add wasm32-unknown-unknown && \
+  cargo install --force --git https://github.com/oasislabs/owasm-utils.git && \
+  cargo install --force --features evm-debug --git https://github.com/oasislabs/parity-ethereum parity-ethereum --bin parity
+
+FROM ubuntu:18.04
+
+COPY --from=intermediate /root/.cargo/bin /root/.cargo/bin
+

--- a/docker/docker_build_and_push.sh
+++ b/docker/docker_build_and_push.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+
+#########################################
+# 1. Builds a new deployment image of
+#    oasislabs/parity-ethereum
+#    and tags it with the provided tag.
+# 2. Push deployment image to Docker Hub.
+#########################################
+
+# Helpful tips on writing build scripts:
+# https://buildkite.com/docs/pipelines/writing-build-scripts
+set -euxo pipefail
+
+###############
+# Required args
+###############
+git_commit_sha=$1
+docker_image_tag=$2
+
+#################
+# Local variables
+#################
+docker_image_name=oasislabs/parity-ethereum
+
+####################################
+# Build and publish the docker image
+####################################
+
+set +x
+# The docker command will contain the SSH private key
+# in plain text and we don't want that getting into bash
+# history, so we intentionally disable printing commands
+# with set +x.
+set -x
+
+# Build the deployable image
+docker build --rm --force-rm \
+  --build-arg PARITY_ETHEREUM_BUILD_IMAGE_TAG=${docker_image_tag} \
+  --build-arg PARITY_ETHEREUM_COMMIT_SHA=${git_commit_sha} \
+  --build-arg GITHUB_USER=${GITHUB_USER} \
+  --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
+  -t ${docker_image_name}:${docker_image_tag} \
+  -f docker/Dockerfile .
+
+docker push ${docker_image_name}:${docker_image_tag}
+
+# Remove the intermediate docker images that contain
+# the private SSH key
+docker rmi -f $(docker images -q --filter label=stage=intermediate)

--- a/docker/librocksdb.pc
+++ b/docker/librocksdb.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=/usr/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+Name: RocksDB
+Description: persistent Key-Value Store for Flash and RAM Storage
+Version: 5.8.8
+Libs: -L${libdir} -lrocksdb
+Cflags: -I${includedir}
+


### PR DESCRIPTION
This image is the base image for contract kit. It contains parity.
Saves us about 65% of our build time for c-k.