### PR TITLE
Increase Oasis chain maxTransactionSize

### DIFF
--- a/ethcore/res/ethereum/oasis.json
+++ b/ethcore/res/ethereum/oasis.json
@@ -10,6 +10,7 @@
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
     "networkID" : "0xa516",
+		"maxTransactionSize": 4294967296,
     "maxCodeSize": 4294967296,
     "maxCodeSizeTransition": "0x0",
     "eip86Transition": "0xffffffffffffffff",

--- a/ethcore/res/ethereum/oasis.json
+++ b/ethcore/res/ethereum/oasis.json
@@ -10,7 +10,7 @@
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
     "networkID" : "0xa516",
-		"maxTransactionSize": 4294967296,
+    "maxTransactionSize": 4294967296,
     "maxCodeSize": 4294967296,
     "maxCodeSizeTransition": "0x0",
     "eip86Transition": "0xffffffffffffffff",


### PR DESCRIPTION
[The default `maxTransactionSize` is 300 KiB](https://wiki.parity.io/Chain-specification) which actually prevents deploying a contract with our larger `maxCodeSize`.