### PR TITLE
Add buildkite agent requirements to jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,8 @@ steps:
 
   - label: Build docker image (all branch commits)
     branches: "*"
+    agents:
+      buildkite_agent_size: large
     command:
       - .buildkite/scripts/build_tag_push_deployment_image.sh
 


### PR DESCRIPTION
Jobs that need a large amount of resources to run
can now specify that requirement in the agents
stanza so that they always run on build agents
with enough resources.