### PR TITLE
Mark docker promotion job as stable

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,5 +24,7 @@ steps:
 
   - label: Deploy docker image (master only)
     branches: master
+    agents:
+      buildkite_agent_class: stable
     command:
       - .buildkite/scripts/promote_deployment_image_to.sh latest


### PR DESCRIPTION
Mark the job promoting docker image as requiring a stable buildkite agent.